### PR TITLE
Agrega archivos CSV comprimidos usando git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv.gz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
+
+# Ignore CSV raw
+*.csv

--- a/CodigoEquipo2.Rmd
+++ b/CodigoEquipo2.Rmd
@@ -46,8 +46,8 @@ library(data.table)
 library(dplyr)
 library(ggplot2)
 library(here)
-tbi_file <- here("fpkm_table_normalized.csv")
-processed_rna_file <- here("rna_data.csv")
+tbi_file <- here("fpkm_table_normalized.csv.gz")
+processed_rna_file <- here("rna_data.csv.gz")
 
 ```
 

--- a/fpkm_table_normalized.csv.gz
+++ b/fpkm_table_normalized.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84afd7c2a0bc96319681e97f475937ab6e8480b2685cd8d4d4b336186a85c35f
+size 103690416

--- a/rna_data.csv.gz
+++ b/rna_data.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95dea28b68a2deade782d71da635c6915e6240bb78203e8212188ebebc895e7a
+size 172891829


### PR DESCRIPTION
Agrega los archivos comprimidos para su lectura con terminación `csv.gz`

Estos usan el sistema git lfs para su uso, es probable que requiera instalación

> Cuidado es posible que esta implementación no funcione en **Windows** revisne la funcionalidad de la rama antes de incluirla @JuanCarlosGomezM 